### PR TITLE
fix rowindex when we have many xml files - closes #6

### DIFF
--- a/lang-tool/src/main/java/cz/tomaskypta/tools/langtool/exporting/ToolExport.java
+++ b/lang-tool/src/main/java/cz/tomaskypta/tools/langtool/exporting/ToolExport.java
@@ -130,6 +130,7 @@ public class ToolExport {
                 continue;
             }
             keys.putAll(exportDefLangToExcel(rowIndex, project, stringFile, getStrings(stringFile), outExcelFile));
+            rowIndex = keys.size() + 1;
         }
 
 


### PR DESCRIPTION
this commit fixes the issue when you have multiple xml files specified in command line
https://github.com/TomasKypta/android-lang-tool/issues/6

Normally the rows are being overwritten by next file, not appended on the bottom of sheet.