### PR TITLE
Fix NPE when default language is not processed first

### DIFF
--- a/lang-tool/src/main/java/cz/tomaskypta/tools/langtool/exporting/ToolExport.java
+++ b/lang-tool/src/main/java/cz/tomaskypta/tools/langtool/exporting/ToolExport.java
@@ -67,14 +67,21 @@ public class ToolExport {
             System.err.println("Cannot find resource directory.");
             return;
         }
+
+        // Process default language first to populate keysIndex
+        // keysIndex is used to keep track of missing keys
+        for (File dir : res.listFiles()) {
+            if (!dir.isDirectory() || !dir.getName().equals(DIR_VALUES)) {
+                continue;
+            }
+            keysIndex = exportDefLang(dir);
+        }
         for (File dir : res.listFiles()) {
             if (!dir.isDirectory() || !dir.getName().startsWith(DIR_VALUES)) {
                 continue;
             }
             String dirName = dir.getName();
-            if (dirName.equals(DIR_VALUES)) {
-                keysIndex = exportDefLang(dir);
-            } else {
+            if (!dirName.equals(DIR_VALUES)) {
                 int index = dirName.indexOf('-');
                 if (index == -1)
                     continue;


### PR DESCRIPTION
For some reason `listFiles` decided to list `values-el-rGR` before `values`. This meant `keysIndex` was not set, leading to a null pointer exception.

Fixed by first processing the `values` dir, and then any other languages.